### PR TITLE
Use futures sub-crates explicitly

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -33,18 +33,17 @@ jobs:
             override: true
 
       - name: Run cargo check
-        if: "!startsWith(matrix.rust, 'nightly')"
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --all --benches --bins --examples --tests --all-features
 
-      - name: Run cargo check (without dev-dependencies)
+      - name: Run cargo check (without dev-dependencies to catch missing feature flags)
         if: startsWith(matrix.rust, 'nightly')
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: -Z features=dev_dep --all --benches --bins --examples --tests --all-features
+          args: -Z features=dev_dep
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -33,6 +33,7 @@ jobs:
             override: true
 
       - name: Run cargo check
+        if: !startsWith(matrix.rust, 'nightly')
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -33,7 +33,7 @@ jobs:
             override: true
 
       - name: Run cargo check
-        if: !startsWith(matrix.rust, 'nightly')
+        if: "!startsWith(matrix.rust, 'nightly')"
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -38,6 +38,13 @@ jobs:
           command: check
           args: --all --benches --bins --examples --tests --all-features
 
+      - name: Run cargo check (without dev-dependencies)
+        if: startsWith(matrix.rust, 'nightly')
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -Z features=dev_dep --all --benches --bins --examples --tests --all-features
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "concurrency"]
 readme = "README.md"
 
 [dependencies]
-futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.5", default-features = false, features = ["std", "sink"] }
 futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 once_cell = "1.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ categories = ["asynchronous", "concurrency"]
 readme = "README.md"
 
 [dependencies]
-futures = { version = "0.3.4", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-core = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 once_cell = "1.3.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 futures-util = { version = "0.3.5", default-features = false, features = ["std", "sink"] }
-futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-channel = { version = "0.3.5", default-features = false, features = ["std", "sink"] }
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 once_cell = "1.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 [dependencies]
 futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-channel = { version = "0.3.5", default-features = false, features = ["std"] }
-futures-core = { version = "0.3.5", default-features = false, features = ["std"] }
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 once_cell = "1.3.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,10 @@ use std::thread;
 use std::time::Duration;
 
 use futures_util::task::{ArcWake, waker_ref, AtomicWaker};
-use futures_util::future;
+use futures_util::future::{self, Future};
 use futures_util::sink::SinkExt;
-use futures_core::{Stream, Future, ready};
+use futures_util::stream::{Stream};
+use futures_util::ready;
 use futures_io::{AsyncRead, AsyncWrite};
 use futures_channel::{mpsc, oneshot};
 use once_cell::sync::Lazy;


### PR DESCRIPTION
This bring initial compile times (using `cargo check`) down from ~22s to ~14s, while reducing the amount of dependencies from 25 to 23.

Please let me know if you would like to see any changes.

**edit**: These amazing build time improvements cannot be reproduced anymore. Probably just a local fluke :/.