### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smol-rs/blocking"
 documentation = "https://docs.rs/blocking"
 keywords = ["async", "file", "stdio", "stdin", "process"]
 categories = ["asynchronous", "concurrency"]
-readme = "README.md"
 
 [dependencies]
 async-channel = "1.4.0"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.