### PR TITLE
unblock returns Task

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,9 +92,9 @@ use std::task::{Context, Poll};
 use std::thread;
 use std::time::Duration;
 
-pub use async_task::Task;
 use async_channel::{bounded, Receiver};
 use async_task::Runnable;
+pub use async_task::Task;
 use atomic_waker::AtomicWaker;
 use futures_lite::{future, prelude::*, ready};
 use once_cell::sync::Lazy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,9 @@ use std::task::{Context, Poll};
 use std::thread;
 use std::time::Duration;
 
+pub use async_task::Task;
 use async_channel::{bounded, Receiver};
-use async_task::{Runnable, Task};
+use async_task::Runnable;
 use atomic_waker::AtomicWaker;
 use futures_lite::{future, prelude::*, ready};
 use once_cell::sync::Lazy;
@@ -267,12 +268,12 @@ impl Executor {
 /// let out = unblock(|| Command::new("dir").output()).await?;
 /// # std::io::Result::Ok(()) });
 /// ```
-pub async fn unblock<T, F>(f: F) -> T
+pub fn unblock<T, F>(f: F) -> Task<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    Executor::spawn(async move { f() }).await
+    Executor::spawn(async move { f() })
 }
 
 /// Runs blocking I/O on a thread pool.


### PR DESCRIPTION
This PR makes it so that the unblock function returns a `Task` (which implements `Future`) instead of an opaque `Future`. This gives the application more opportunity for optimization knowing the exact type of the future to be returned.

This also re-exports the `Task` type from `async_task` to make this easier to use.