### PR TITLE
v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 1.4.0
+
+- Bump MSRV to 1.59. (#44)
+- Remove the unused `memchr` dependency. (#38)
+- Extract read/write pipes into the `piper` crate, which this crate now uses. (#37)
+- Mark as `forbid(unsafe_code)` (#37).
+- Set up logging using `tracing`. (#40)
+
 # Version 1.3.1
 
 - Gracefully handle the inability to spawn threads. (#31)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "blocking"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.3.1"
+version = "1.4.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.59"


### PR DESCRIPTION
- Bump MSRV to 1.59. (#44)
- Remove the unused `memchr` dependency. (#38)
- Extract read/write pipes into the `piper` crate, which this crate now uses. (#37)
- Mark as `forbid(unsafe_code)` (#37).
- Set up logging using `tracing`. (#40)