### PR TITLE
Change executor grow_pool function error_span to tracing_span

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ impl Executor {
 
     /// Spawns more blocking threads if the pool is overloaded with work.
     fn grow_pool(&'static self, mut inner: MutexGuard<'static, Inner>) {
-        let span = tracing::error_span!(
+        let span = tracing::trace_span!(
             "grow_pool",
             queue_len = inner.queue.len(),
             idle_count = inner.idle_count,


### PR DESCRIPTION
After I update blocking dependency to v1.4.0, this error log pop up.
`grow_pool; queue_len=1 idle_count=0 thread_count=0`

I think this might just a typo for trace level? (cc #40)
https://github.com/smol-rs/blocking/blob/c3b5e01b3ca47ee7861f0491f8681736422d109a/src/lib.rs#L246-L254