### PR TITLE
v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.4.1
+
+- Change the `error_span` in `grow_pool` into `trace_span`. (#45)
+
 # Version 1.4.0
 
 - Bump MSRV to 1.59. (#44)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "blocking"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.59"


### PR DESCRIPTION
- Change the `error_span` in `grow_pool` into `trace_span`. (#45)