### PR TITLE
Fix redundant import warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,11 @@ use std::env;
 use async_channel::{bounded, Receiver};
 use async_task::Runnable;
 use futures_io::{AsyncRead, AsyncSeek, AsyncWrite};
-use futures_lite::{future, prelude::*, ready};
+use futures_lite::{
+    future::{self, Future},
+    ready,
+    stream::Stream,
+};
 use piper::{pipe, Reader, Writer};
 
 #[doc(no_inline)]


### PR DESCRIPTION
```
error: the item `AsyncRead` is imported redundantly
   --> src/lib.rs:105:18
    |
105 | use futures_io::{AsyncRead, AsyncSeek, AsyncWrite};
    |                  ^^^^^^^^^
106 | use futures_lite::{future, prelude::*, ready};
    |                            ---------- the item `AsyncRead` is already imported here
    |
    = note: `-D unused-imports` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: the item `AsyncSeek` is imported redundantly
   --> src/lib.rs:105:29
    |
105 | use futures_io::{AsyncRead, AsyncSeek, AsyncWrite};
    |                             ^^^^^^^^^
106 | use futures_lite::{future, prelude::*, ready};
    |                            ---------- the item `AsyncSeek` is already imported here

error: the item `AsyncWrite` is imported redundantly
   --> src/lib.rs:105:40
    |
105 | use futures_io::{AsyncRead, AsyncSeek, AsyncWrite};
    |                                        ^^^^^^^^^^
106 | use futures_lite::{future, prelude::*, ready};
    |                            ---------- the item `AsyncWrite` is already imported here
```