### PR TITLE
Propogate panics that occur in unblocked functions

### DIFF
--- a/tests/unblock.rs
+++ b/tests/unblock.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use std::io::{Cursor, SeekFrom};
+use std::panic::AssertUnwindSafe;
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -100,4 +101,37 @@ fn seek() {
         v.read(&mut byte).await.unwrap();
         assert_eq!(byte[0], 15);
     })
+}
+
+#[test]
+fn panic() {
+    future::block_on(async {
+        let x = unblock(|| panic!("expected failure"));
+        let panic = x.catch_unwind().await.unwrap_err();
+
+        // Make sure it's our panic and not an unrelated one.
+        let msg = if let Some(msg) = panic.downcast_ref::<&'static str>() {
+            msg.to_string()
+        } else {
+            *panic.downcast::<String>().unwrap()
+        };
+        assert_eq!(msg, "expected failure");
+    });
+}
+
+#[test]
+fn panic_with_mut() {
+    future::block_on(async {
+        let mut io = Unblock::new(());
+        let x = io.with_mut(|()| panic!("expected failure"));
+        let panic = AssertUnwindSafe(x).catch_unwind().await.unwrap_err();
+
+        // Make sure it's our panic and not an unrelated one.
+        let msg = if let Some(msg) = panic.downcast_ref::<&'static str>() {
+            msg.to_string()
+        } else {
+            *panic.downcast::<String>().unwrap()
+        };
+        assert_eq!(msg, "`Unblock::with_mut()` operation has panicked: RecvError");
+    });
 }

--- a/tests/unblock.rs
+++ b/tests/unblock.rs
@@ -132,6 +132,9 @@ fn panic_with_mut() {
         } else {
             *panic.downcast::<String>().unwrap()
         };
-        assert_eq!(msg, "`Unblock::with_mut()` operation has panicked: RecvError");
+        assert_eq!(
+            msg,
+            "`Unblock::with_mut()` operation has panicked: RecvError"
+        );
     });
 }


### PR DESCRIPTION
This commit makes it so if a panic occurs in an unblock task, that panic
is propogated to the caller. Previously, the task would just fail to
complete and would produce a less intuitive error.

Tests are also added to make sure the panic is propogated.
