### PR TITLE
Remove fastrand dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = ["/.*"]
 [dependencies]
 async-channel = "2.0.0"
 async-task = "4.0.2"
-fastrand = "2.0.0"
 futures-io = { version = "0.3.28", default-features = false, features = ["std"] }
 futures-lite = { version = "2.0.0", default-features = false }
 piper = "0.2.0"


### PR DESCRIPTION
fastrand isn't being used anywhere in the crate. This PR removes it as a required dependency.