### PR TITLE
v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 1.6.0
+
+- Panics that occur in `unblock`ed functions are now propagated to the calling
+  function. (#58)
+- Add a new optional `tracing` feature. When enabled, this feature adds logging
+  to the implementation. By default it is disabled. (#60)
+- Remove the unused `fastrand` dependency. (#61)
+
 # Version 1.5.1
 
 - Fix compilation on WebAssembly targets (#54).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "blocking"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.5.1"
+version = "1.6.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
- Panics that occur in `unblock`ed functions are now propagated to the calling
  function. (#58)
- Add a new optional `tracing` feature. When enabled, this feature adds logging
  to the implementation. By default it is disabled. (#60)
- Remove the unused `fastrand` dependency. (#61)
