### PR TITLE
v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.6.1
+
+- Remove our dependency on the `async-lock` crate. (#59)
+
 # Version 1.6.0
 
 - Panics that occur in `unblock`ed functions are now propagated to the calling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "blocking"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Remove our dependency on the `async-lock` crate. (#59)
