### PR TITLE
ci: Use reusable workflows for fmt and security_audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+  fmt:
+    uses: smol-rs/.github/.github/workflows/fmt.yml@main
+  security_audit:
+    uses: smol-rs/.github/.github/workflows/security_audit.yml@main
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+    secrets: inherit
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -62,14 +72,6 @@ jobs:
         run: rustup update stable
       - run: cargo clippy --all-features --all-targets
 
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo fmt --all --check
-
   miri:
     runs-on: ubuntu-latest
     steps:
@@ -81,19 +83,3 @@ jobs:
           # -Zmiri-ignore-leaks is needed because we use detached threads in tests/docs: https://github.com/rust-lang/miri/issues/1371
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout
-
-  security_audit:
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # rustsec/audit-check used to do this automatically
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-      # https://github.com/rustsec/audit-check/issues/2
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See https://github.com/smol-rs/.github/pull/1 for details about reusable workflows.
